### PR TITLE
Login to ECR if AWS_PROFILE env present

### DIFF
--- a/docker-helper
+++ b/docker-helper
@@ -6,11 +6,17 @@ CMD="$1"
 
 login()
 {
-    if [ -z "${DOCKER_USER:-}" ] || [ -z "${DOCKER_PASS:-}" ]; then
-        echo "Please set DOCKER_USER and DOCKER_PASS environment variables."
-        exit 1
+    if [ -z "${AWS_PROFILE:-}" ]; then
+        echo "Using Docker Hub login"
+        if [ -z "${DOCKER_USER:-}" ] || [ -z "${DOCKER_PASS:-}" ]; then
+            echo "Please set DOCKER_USER and DOCKER_PASS environment variables."
+            exit 1
+        fi
+        docker login -u $DOCKER_USER -p $DOCKER_PASS
+    else
+        echo "Using ECR login"
+        $(aws ecr get-login --no-include-email)
     fi
-    docker login -u $DOCKER_USER -p $DOCKER_PASS
 }
 
 case $CMD in


### PR DESCRIPTION
This PR makes docker-helper use ECR login instead of Docker hub if the AWS_PROFILE variable is present.

I'm not sure if this is an appropriate flag, or if we should have a more explicit "ECR_LOGIN=1" flag or yet another command line argument to enable this, but opening it up for discussion.