### PR TITLE
[breaking] removed extra lines in docker-helper that formatted dockerhub repos to GHPR repos

### DIFF
--- a/docker-helper
+++ b/docker-helper
@@ -93,7 +93,7 @@ case $CMD in
 
         # if aws_profile set, push to AWS
         if [ -n "${AWS_PROFILE:-}" ]; then
-            echo "Pushing to ECR"
+            echo "Pushing to ECR: $REPO"
             docker push $REPO
             if [ $? -ne 0 ]; then
                 echo "Push to AWS ECR failed. $REPO"

--- a/docker-helper
+++ b/docker-helper
@@ -85,7 +85,7 @@ case $CMD in
         # if github credentials set, push to github
         if [ -n "${GITHUB_USERNAME:-}" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
             echo "Pushing to Github Package Registry"
-            docker push $REPO
+            docker push $REPO:ci
             if [ $? -ne 0 ]; then
                 echo "Push to $REPO failed"
             fi

--- a/docker-helper
+++ b/docker-helper
@@ -28,7 +28,6 @@ case $CMD in
         BUILD_PATH="$3"
         PROJ_NAME=$(basename $REPO)
         CI_TAG="$REPO:ci"
-        GITHUB_REPO="docker.pkg.github.com/$REPO/$PROJ_NAME"
 
         # Logic to determine the BRANCH tag. sed portion turns + and / into -
         # git rev-parse helps us get the repo's branch name
@@ -70,18 +69,10 @@ case $CMD in
         docker tag $CI_TAG $REPO:"build-$BUILD_NUMBER"
         docker tag $CI_TAG $REPO:"ci"
         echo "Tagged $CI_TAG with sha-$COMMIT, branch-$BRANCH, build-$BUILD_NUMBER, and ci"
-
-        # if github credentials set, add github repo tags
-        if [ -n "${GITHUB_USERNAME:-}" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
-            docker tag $CI_TAG $GITHUB_REPO:"sha-$COMMIT"
-            docker tag $CI_TAG $GITHUB_REPO:"branch-$BRANCH"
-            echo "Tagged $CI_TAG with $GITHUB_REPO:sha-$COMMIT and $GITHUB_REPO:branch-$BRANCH"
-        fi
     ;;
     push)
         REPO="$2"
         PROJ_NAME=$(basename $REPO)
-        GITHUB_REPO="docker.pkg.github.com/$REPO/$PROJ_NAME"
 
         login
 
@@ -94,9 +85,9 @@ case $CMD in
         # if github credentials set, push to github
         if [ -n "${GITHUB_USERNAME:-}" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
             echo "Pushing to Github Package Registry"
-            docker push $GITHUB_REPO
+            docker push $REPO
             if [ $? -ne 0 ]; then
-                echo "Push to $GITHUB_REPO failed"
+                echo "Push to $REPO failed"
             fi
         fi
 

--- a/docker-helper
+++ b/docker-helper
@@ -78,16 +78,16 @@ case $CMD in
 
         # if dockerhub credentials set, push dockerhub
         if [ -n "${DOCKER_USER:-}" ] && [ -n "${DOCKER_PASS:-}" ]; then
-            echo "Pushing to Dockerhub"
+            echo "Pushing to Dockerhub: $REPO"
             docker push $REPO
         fi
 
         # if github credentials set, push to github
         if [ -n "${GITHUB_USERNAME:-}" ] && [ -n "${GITHUB_TOKEN:-}" ]; then
-            echo "Pushing to Github Package Registry"
-            docker push $REPO:ci
+            echo "Pushing to Github Package Registry: $REPO/$PROJ_NAME"
+            docker push $REPO/$PROJ_NAME
             if [ $? -ne 0 ]; then
-                echo "Push to $REPO failed"
+                echo "Push to $REPO/$PROJ_NAME failed"
             fi
         fi
 


### PR DESCRIPTION
When I first tweaked the docker-helper script, I assumed the `repo` input would have to match dockerhub's format. I wrote a few extra lines that took in `chanzuckerberg/projname` and reformatted it to `docker.pkg.github.com/chanzuckerberg/projname`. 

To keep things simpler, I removed all references to the `GITHUB_REPO` and github-specific conditionals. 

Next steps:
1. Make a new release of infra-tools
2. Updating reaper's .travis.yml file so it references v0.0.4
3. Updating oauth2_proxy's .travis.yml file so it references v0.0.4
4. Updating the Dockerhub Migration doc so it references v0.0.4 and change GHPR repo inputs from chanzuckerberg/proj to docker.pkg.github.com/chanzuckerberg/proj